### PR TITLE
Enhancement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Nostr-Hooks
 
+## 2.8.0
+
+- Improved `useSubscribe` hook to react to the changes in the input parameters.
+
+### Breaking Changes
+
+- `useSubscribe` hook is now sensitive to all the input parameters. If any of the input parameters change, the hook will unsubscribe from the previous subscription and subscribe to the new one. This will help you to subscribe to different filters based on the input parameters. You need to make sure that the input parameters are memoized and don't change on every render to avoid infinite re-render loops. You can find examples in README.
+- `useNostrHooks` hook is now sensitive to the initial NDK instance parameter. You need to make sure that the initial NDK instance is memoized and doesn't change on every render to avoid infinite re-render loops. You can find examples in README.
+
 ## 2.7.0
 
 - Improved interacting with different signers.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,23 @@ const App = () => {
 };
 ```
 
-> You can also pass a custom NDK instance to the `useNostrHooks` hook. This is useful when you want to initiate your app with a custom NDK instance with your own configuration. You can also use other provided hooks like `useNdk` to interact with the NDK instance later.
+You can also pass a custom NDK instance to the `useNostrHooks` hook. This is useful when you want to initiate your app with a custom NDK instance with your own configuration.
+
+```jsx
+import { useNostrHooks } from 'nostr-hooks';
+
+const customNDK = new NDK({
+  /* ... */
+});
+
+const App = () => {
+  useNostrHooks(customNDK);
+
+  return <YourApp />;
+};
+```
+
+> Make sure to create you custom NDK instance outside of the component body to prevent re-creating it on every render. You can also use the `useMemo` hook to memoize the custom NDK instance if you want to re-create it when some dependencies change.
 
 ### Subscribe to events
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nostr-hooks",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "React hooks for developing Nostr clients.",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -2,22 +2,19 @@ import NDK, { NDKSigner } from '@nostr-dev-kit/ndk';
 import cloneDeep from 'lodash/cloneDeep';
 import { create } from 'zustand';
 
-type State = {
+type NDKState = {
   ndk: NDK;
 };
 
-type Actions = {
+type NDKActions = {
   setNdk: (ndk: NDK) => void;
+};
+
+type SignerActions = {
   setSigner: (signer: NDKSigner | undefined) => void;
 };
 
-/**
- * Custom hook for managing NDK (Nostr Development Kit) instance.
- */
-export const useStore = create<State & Actions>((set) => ({
-  /**
-   * The NDK instance.
-   */
+export const useStore = create<NDKState & NDKActions & SignerActions>()((set, get) => ({
   ndk: new NDK({
     explicitRelayUrls: [
       'wss://nos.lol',
@@ -35,16 +32,8 @@ export const useStore = create<State & Actions>((set) => ({
     ],
   }),
 
-  /**
-   * Sets the NDK instance.
-   * @param ndk - The new NDK instance.
-   */
-  setNdk: (ndk) => ({ ndk }),
+  setNdk: (ndk) => set({ ndk }),
 
-  /**
-   * Sets the signer for the current NDK instance.
-   * @param signer - The new signer.
-   */
   setSigner: (signer) =>
     set((state) => {
       if (!state.ndk) return state;


### PR DESCRIPTION
## 2.8.0

- Improved `useSubscribe` hook to react to the changes in the input parameters.

### Breaking Changes

- `useSubscribe` hook is now sensitive to all the input parameters. If any of the input parameters change, the hook will unsubscribe from the previous subscription and subscribe to the new one. This will help you to subscribe to different filters based on the input parameters. You need to make sure that the input parameters are memoized and don't change on every render to avoid infinite re-render loops. You can find examples in README.
- `useNostrHooks` hook is now sensitive to the initial NDK instance parameter. You need to make sure that the initial NDK instance is memoized and doesn't change on every render to avoid infinite re-render loops. You can find examples in README.