### PR TITLE
Add Support for Custom NDK instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Nostr-Hooks
 
+## 2.9.8
+
+- Added support for custom NDK instances. Now you can pass a custom NDK instance to all the hooks, but you need to execute `ndk.connect()` manually once you create a custom NDK instance.
+
 ## 2.9.2
 
 - Replaces `useProfiles` with `useProfile` hook.

--- a/README.md
+++ b/README.md
@@ -369,13 +369,13 @@ const MyComponent = () => {
 
 You can use the `useLogin` hook to login with different signers. This hook will automatically update the NDK instance with the new signer. It also uses local storage to persist the login method, so the user doesn't need to login manually every time the page reloads or the app restarts.
 
-> The `useLogin` hook provides 4 methods for logging in with different signers, and 1 method for logging out:
->
-> - `loginWithExtention`: Login with Nostr Extention (NIP07).
-> - `loginWithRemoteSigner`: Login with Remote Signer (NIP46).
-> - `loginWithSecretKey`: Login with Secret Key.
-> - `loginFromLocalStorage`: Login from previously saved login method in local storage.
-> - `logout`: Logout.
+The `useLogin` hook provides 4 methods for logging in with different signers, and 1 method for logging out:
+
+- `loginWithExtention`: Login with Nostr Extention (NIP07).
+- `loginWithRemoteSigner`: Login with Remote Signer (NIP46).
+- `loginWithSecretKey`: Login with Secret Key.
+- `loginFromLocalStorage`: Login from previously saved login method in local storage.
+- `logout`: Logout.
 
 ```jsx
 import { useLogin } from 'nostr-hooks';
@@ -400,6 +400,28 @@ const MyComponent = () => {
   );
 };
 ```
+
+#### Using a custom NDK instance:
+
+If you are using a custom NDK instance, you can pass it to the `useLogin` hook along with its setter function to update your custom NDK instance with the new signer instead of the default NDK instance.
+
+```tsx
+import { useLogin } from 'nostr-hooks';
+
+const MyComponent = () => {
+  const [customNdk, setCustomNdk] = useState<NDK>(
+    new NDK({
+      /* ... */
+    })
+  );
+
+  const { loginWithExtention } = useLogin({ customNdk, setCustomNdk });
+
+  return <button onClick={() => loginWithExtention()}>Login with Extention</button>;
+};
+```
+
+#### Automatically login with previously saved login method:
 
 You can also use `useAutoLogin` hook to automatically login with previously saved login method in local storage when the component mounts.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nostr-hooks",
-  "version": "2.9.7",
+  "version": "2.9.8",
   "description": "React hooks for developing Nostr clients",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/src/hooks/use-active-user/index.ts
+++ b/src/hooks/use-active-user/index.ts
@@ -1,4 +1,4 @@
-import { NDKUser } from '@nostr-dev-kit/ndk';
+import NDK, { NDKUser } from '@nostr-dev-kit/ndk';
 import { useEffect, useState } from 'react';
 
 import { useSigner } from '../use-signer';
@@ -9,17 +9,20 @@ import { useSigner } from '../use-signer';
  * @param fetchProfile - Optional boolean indicating whether to fetch profile for the active user. Default is false.
  * @returns An object containing the active user or undefined if there is no active user.
  */
-export const useActiveUser = (options?: { fetchProfile?: boolean | undefined }) => {
+export const useActiveUser = (params?: {
+  fetchProfile?: boolean | undefined;
+  customNdk?: NDK | undefined;
+}) => {
   const [activeUser, setActiveUser] = useState<NDKUser | undefined>(undefined);
 
-  const { signer } = useSigner();
+  const { signer } = useSigner(params?.customNdk ? { customNdk: params.customNdk } : undefined);
 
   useEffect(() => {
     if (signer) {
       signer.user().then((user) => {
         if (!user) return;
 
-        if (options?.fetchProfile) {
+        if (params?.fetchProfile) {
           user.fetchProfile().finally(() => {
             setActiveUser(user);
           });
@@ -30,7 +33,7 @@ export const useActiveUser = (options?: { fetchProfile?: boolean | undefined }) 
     } else {
       setActiveUser(undefined);
     }
-  }, [signer, options?.fetchProfile]);
+  }, [signer, params?.fetchProfile]);
 
   return { activeUser };
 };

--- a/src/hooks/use-auto-login/index.ts
+++ b/src/hooks/use-auto-login/index.ts
@@ -1,9 +1,20 @@
+import NDK from '@nostr-dev-kit/ndk';
 import { useEffect } from 'react';
 
 import { useLogin } from '../use-login';
 
-export const useAutoLogin = () => {
-  const { loginFromLocalStorage } = useLogin();
+type Params = {
+  customNdk: NDK;
+  setCustomNdk: (customNdk: NDK) => void;
+};
+
+/**
+ * Custom hook for automatic login functionality based on previously stored login method in local storage.
+ *
+ * @param params - Optional parameters for custom NDK instance and its setter function.
+ */
+export const useAutoLogin = (params?: Params) => {
+  const { loginFromLocalStorage } = useLogin(params);
 
   useEffect(() => {
     loginFromLocalStorage();

--- a/src/hooks/use-login/index.ts
+++ b/src/hooks/use-login/index.ts
@@ -1,4 +1,4 @@
-import { NDKNip07Signer, NDKNip46Signer, NDKPrivateKeySigner } from '@nostr-dev-kit/ndk';
+import NDK, { NDKNip07Signer, NDKNip46Signer, NDKPrivateKeySigner } from '@nostr-dev-kit/ndk';
 import { useLocalStorage } from '@uidotdev/usehooks';
 import { useCallback } from 'react';
 
@@ -11,19 +11,25 @@ enum LoginMethod {
   SecretKey = 'secret-key',
 }
 
+type Params = {
+  customNdk: NDK;
+  setCustomNdk: (customNdk: NDK) => void;
+};
+
 /**
  * Custom hook for handling login functionality.
  * This hook provides methods for logging in with different login methods,
  * such as extension (NIP07), remote signer (NIP46), and secret key.
  * It also provides a method for re-logging in from previously stored login method in local storage.
  *
+ * @param params - Optional parameters for custom NDK instance and its setter function.
  * @returns An object containing the following methods:
  * - `loginWithExtention`: A function for logging in with the extension method (NIP07).
  * - `loginWithRemoteSigner`: A function for logging in with the remote signer method (NIP46).
  * - `loginWithSecretKey`: A function for logging in with the secret key method.
  * - `reLoginFromLocalStorage`: A function for re-logging in from previously stored login method in local storage.
  */
-export const useLogin = () => {
+export const useLogin = (params?: Params) => {
   const [localLoginMethod, setLocalLoginMethod] = useLocalStorage<LoginMethod | undefined>(
     'login-method',
     undefined
@@ -38,7 +44,7 @@ export const useLogin = () => {
   );
 
   const { ndk } = useNdk();
-  const { signer, setSigner } = useSigner();
+  const { signer, setSigner } = useSigner(params);
 
   const loginWithExtention = useCallback(
     (options?: { onSuccess?: (signer: NDKNip07Signer) => void; onError?: (err: any) => void }) => {

--- a/src/hooks/use-new-event/index.ts
+++ b/src/hooks/use-new-event/index.ts
@@ -1,9 +1,19 @@
-import { NDKEvent } from '@nostr-dev-kit/ndk';
+import NDK, { NDKEvent } from '@nostr-dev-kit/ndk';
 
 import { useNdk } from '../use-ndk';
 
-export const useNewEvent = () => {
-  const { ndk } = useNdk();
+/**
+ * Custom hook for creating a new event.
+ *
+ * @param customNdk - Optional custom NDK instance to use instead of the global NDK instance.
+ * @returns An object with a `createNewEvent` function that creates a new NDKEvent instance with the provided NDK instance.
+ */
+export const useNewEvent = (params?: { customNdk?: NDK | undefined }) => {
+  // Get reactive NDK instance from the global store
+  const { ndk: globalNdk } = useNdk();
+
+  // Use the custom NDK instance if provided
+  const ndk = params?.customNdk || globalNdk;
 
   const createNewEvent = () => new NDKEvent(ndk);
 

--- a/src/hooks/use-profile/index.ts
+++ b/src/hooks/use-profile/index.ts
@@ -11,19 +11,25 @@ type ProfileParams = {
   relayUrls?: string[];
 };
 
-export const useProfile = (profileParams?: ProfileParams, ndk?: NDK) => {
+/**
+ * Custom hook for fetching a user profile.
+ *
+ * @param profileParams - Optional parameters for fetching the user profile.
+ * @param customNdk - Optional custom NDK instance.
+ * @returns An object containing the user profile or null.
+ */
+export const useProfile = (profileParams?: ProfileParams, customNdk?: NDK) => {
   const [profile, setProfile] = useState<NDKUserProfile | null>(null);
 
-  const { ndk: _ndk } = useNdk();
+  // Get reactive NDK instance from the global store
+  const { ndk: globalNdk } = useNdk();
+
+  // Use the custom NDK instance if provided
+  const ndk = customNdk || globalNdk;
 
   useEffect(() => {
     if (!profileParams) return;
     if (profileParams.constructor === Object && Object.keys(profileParams).length === 0) return;
-
-    if (!ndk) {
-      ndk = _ndk;
-    }
-
     if (!ndk) return;
 
     ndk
@@ -32,7 +38,7 @@ export const useProfile = (profileParams?: ProfileParams, ndk?: NDK) => {
       .then((profile) => {
         setProfile(profile);
       });
-  }, [profileParams, _ndk, ndk]);
+  }, [profileParams, ndk]);
 
   return { profile };
 };

--- a/src/hooks/use-publish/index.ts
+++ b/src/hooks/use-publish/index.ts
@@ -1,14 +1,19 @@
-import { NDKEvent } from '@nostr-dev-kit/ndk';
+import NDK, { NDKEvent, NDKRelay } from '@nostr-dev-kit/ndk';
 
 import { useNdk } from '../use-ndk';
 
 /**
  * Hook for publishing an NDK event.
  *
+ * @param customNdk - Optional NDK instance to use for the publish instead of the global NDK instance.
  * @returns An object containing the `publish` function.
  */
-export const usePublish = () => {
-  const { ndk } = useNdk();
+export const usePublish = (params?: { customNdk?: NDK | undefined }) => {
+  // Get reactive NDK instance from the global store
+  const { ndk: globalNdk } = useNdk();
+
+  // Use the custom NDK instance if provided
+  const ndk = params?.customNdk || globalNdk;
 
   /**
    * Publishes an NDK event.
@@ -16,7 +21,7 @@ export const usePublish = () => {
    * @param event - The NDK event to publish.
    * @returns A Promise that resolves to an array of relay sets. If the event fails to publish, the array will be empty.
    */
-  const publish = async (event: NDKEvent) => {
+  const publish = async (event: NDKEvent): Promise<NDKRelay[]> => {
     if (!ndk) return [];
 
     try {

--- a/src/hooks/use-signer/index.ts
+++ b/src/hooks/use-signer/index.ts
@@ -1,16 +1,36 @@
-import { NDKSigner } from '@nostr-dev-kit/ndk';
+import NDK, { NDKSigner } from '@nostr-dev-kit/ndk';
 import { useCallback } from 'react';
 
 import { useStore } from '../../store';
 
-export const useSigner = () => {
-  const ndk = useStore((state) => state.ndk);
-  const setNdk = useStore((state) => state.setNdk);
+type Params = {
+  customNdk: NDK;
+  setCustomNdk?: (customNdk: NDK) => void;
+};
+
+/**
+ * Custom hook for managing the signer. It can work with the global NDK instance or a custom one.
+ * If a custom NDK instance is provided, it uses the custom NDK instance and its setter function instead of the global NDK instance.
+ * To set the signer of a custom NDK, a custom setter function must be provided.
+ *
+ * @param params - Optional custom NDK instance and its setter function to use instead of the global NDK instance.
+ * @returns An object containing the current signer and a function to update the signer.
+ */
+export const useSigner = (params?: Params) => {
+  // Get reactive NDK instance and its setter function from the global store
+  const globalNdk = useStore((state) => state.ndk);
+  const setGlobalNdk = useStore((state) => state.setNdk);
+
+  // Use the custom NDK instance and its setter function if provided instead of the global NDK instance
+  const ndk = params ? params.customNdk : globalNdk;
+  const setNdk = params ? params.setCustomNdk : setGlobalNdk;
 
   const signer = ndk.signer;
 
   const setSigner = useCallback(
     (signer: NDKSigner | undefined) => {
+      if (!ndk || !setNdk) return;
+
       ndk.signer = signer;
       setNdk(ndk);
     },

--- a/src/hooks/use-subscribe/index.ts
+++ b/src/hooks/use-subscribe/index.ts
@@ -1,4 +1,4 @@
-import {
+import NDK, {
   NDKEvent,
   NDKFilter,
   NDKRelaySet,
@@ -22,6 +22,7 @@ type UseSubscribeParams = {
   enabled?: boolean | undefined;
   relays?: string[] | undefined;
   fetchProfiles?: boolean | undefined;
+  customNdk?: NDK | undefined;
 };
 
 /**
@@ -32,6 +33,7 @@ type UseSubscribeParams = {
  * @param enabled - Optional boolean indicating whether the subscription is enabled. Default is true.
  * @param relays - Optional array of relay URLs to use for this subscription.
  * @param fetchProfiles - Optional boolean indicating whether to fetch profiles for the events. Default is false.
+ * @param customNdk - Optional NDK instance to use for the subscription instead of the global NDK instance.
  * @returns An object containing the sorted events, subscription status, end of stream flag, and an unSubscribe function.
  */
 export const useSubscribe = ({
@@ -40,6 +42,7 @@ export const useSubscribe = ({
   enabled = true,
   relays = undefined,
   fetchProfiles = false,
+  customNdk = undefined,
 }: UseSubscribeParams) => {
   // Initial state
   const initialState = useRef({
@@ -56,7 +59,10 @@ export const useSubscribe = ({
   );
 
   // Get reactive NDK instance from the global store
-  const { ndk } = useNdk();
+  const { ndk: globalNdk } = useNdk();
+
+  // Use the custom NDK instance if provided
+  const ndk = customNdk || globalNdk;
 
   // Get reactive states from the store
   const subscription = useStoreRef.current((state) => state.subscription);


### PR DESCRIPTION
Now we are able to use any external custom NDK instances along with the default internal one. It's mandatory to define custom NDK instances as "reactive states" (for example using `React.useState`, Zustand store, etc.).