### PR TITLE
V4.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ import { useSubscription } from 'nostr-hooks';
 const UserNotes = ({ pubkey }: { pubkey: string | undefined }) => {
   const subId = `${pubkey}-notes`;
 
-  const { events, isLoading, createSubscription, removeSubscription } = useSubscription(subId);
+  const { events, isLoading, createSubscription } = useSubscription(subId);
 
   useEffect(() => {
     if (!pubkey) return;
@@ -91,11 +91,7 @@ const UserNotes = ({ pubkey }: { pubkey: string | undefined }) => {
     const filters = [{ authors: [pubkey], kinds: [1], limit: 50 }];
 
     createSubscription(filters);
-
-    return () => {
-      removeSubscription();
-    };
-  }, [pubkey, createSubscription, removeSubscription]);
+  }, [pubkey, createSubscription]);
 
   if (isLoading) return <p>Loading...</p>;
 
@@ -289,8 +285,7 @@ import { useSubscription } from 'nostr-hooks';
 export const useUserNotes = (pubkey: string | undefined) => {
   const subId = `${pubkey}-notes`;
 
-  const { createSubscription, removeSubscription, events, isLoading, loadMore } =
-    useSubscription(subId);
+  const { events, isLoading, loadMore, createSubscription } = useSubscription(subId);
 
   useEffect(() => {
     if (!pubkey) return;
@@ -298,11 +293,7 @@ export const useUserNotes = (pubkey: string | undefined) => {
     const filters = [{ authors: [pubkey], kinds: [1], limit: 50 }];
 
     createSubscription(filters);
-
-    return () => {
-      removeSubscription();
-    };
-  }, [pubkey, createSubscription, removeSubscription]);
+  }, [pubkey, createSubscription]);
 
   return { events, isLoading, loadMore };
 };
@@ -317,18 +308,6 @@ const subId = `${pubkey}-notes`;
 ```
 
 You can use the same subscription id across multiple components to share the same subscription and events. Nostr-Hooks consolidates all subscriptions from various components into a single request, ensuring each component receives only the events it requires, based on their subscription ids.
-
-#### Cleanup
-
-Always remember to remove subscriptions and clean up events when a component unmounts. This will prevent memory leaks and ensure that your application runs smoothly.
-
-```tsx
-useEffect(() => {
-  return () => {
-    removeSubscription();
-  };
-}, [removeSubscription]);
-```
 
 ## NIP-29
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nostr-hooks",
-  "version": "4.1.9",
+  "version": "4.2.0",
   "description": "React hooks for developing Nostr clients",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/src/hooks/use-subscription/index.ts
+++ b/src/hooks/use-subscription/index.ts
@@ -1,6 +1,6 @@
-import { NDKFilter, NDKSubscriptionOptions } from '@nostr-dev-kit/ndk';
 import { useCallback, useMemo } from 'react';
 
+import { CreateSubscriptionParams } from 'src/types';
 import { useStore } from '../../store';
 import { useNdk } from '../use-ndk';
 
@@ -23,12 +23,8 @@ export const useSubscription = (subId: string | undefined) => {
   const _loadMore = useStore((state) => state.loadMore);
 
   const createSubscription = useCallback(
-    (
-      filters: NDKFilter[],
-      opts?: NDKSubscriptionOptions,
-      relayUrls?: string[],
-      autoStart?: boolean
-    ) => (ndk && subId ? _createSubscription(subId, filters, opts, relayUrls, autoStart) : null),
+    (params: Omit<CreateSubscriptionParams, 'subId'>) =>
+      ndk && subId ? _createSubscription({ ...params, subId }) : null,
     [ndk, _createSubscription, subId]
   );
 
@@ -49,6 +45,12 @@ export const useSubscription = (subId: string | undefined) => {
         : false,
     [subscription?.events, subscription?.eose]
   );
+
+  useCallback(() => {
+    return () => {
+      removeSubscription();
+    };
+  }, [removeSubscription]);
 
   return { ...subscription, createSubscription, removeSubscription, loadMore, isLoading };
 };

--- a/src/nip29/queries/use-group-roles/index.ts
+++ b/src/nip29/queries/use-group-roles/index.ts
@@ -7,19 +7,6 @@ import { Nip29GroupRole } from '../../types';
 
 const updateGroupRoles = useNip29Store.getState().updateGroupRoles;
 
-const onEvent = (subId: string | undefined, groupId: string | undefined, event: NDKEvent) => {
-  const roles: Nip29GroupRole[] = event
-    .getMatchingTags('role')
-    .filter((t) => t.length > 1)
-    .map((t) => {
-      let r: Nip29GroupRole = { name: t[1] || '' };
-      if (t.length > 2) r.description = t[2] || '';
-      return r;
-    });
-
-  updateGroupRoles(subId, groupId, roles);
-};
-
 export const useGroupRoles = (relay: string | undefined, groupId: string | undefined) => {
   const subId = relay && groupId ? `${relay}-${groupId}-roles` : undefined;
 
@@ -27,20 +14,29 @@ export const useGroupRoles = (relay: string | undefined, groupId: string | undef
     subId && groupId ? state.groups[subId]?.[groupId]?.roles : undefined
   );
 
-  const { events, eose, createSubscription, removeSubscription } = useSubscription(subId);
+  const { events, eose, createSubscription } = useSubscription(subId);
 
   useEffect(() => {
     if (!relay || !groupId || !subId) return;
 
     const filters: NDKFilter[] = [{ kinds: [39003 as NDKKind], '#d': [groupId], limit: 1 }];
+    const relayUrls = [relay];
 
-    const sub = createSubscription(filters, {}, [relay]);
-    sub?.on('event', (event) => onEvent(subId, groupId, event));
+    const onEvent = (event: NDKEvent) => {
+      const roles: Nip29GroupRole[] = event
+        .getMatchingTags('role')
+        .filter((t) => t.length > 1)
+        .map((t) => {
+          let r: Nip29GroupRole = { name: t[1] || '' };
+          if (t.length > 2) r.description = t[2] || '';
+          return r;
+        });
 
-    return () => {
-      removeSubscription();
+      updateGroupRoles(subId, groupId, roles);
     };
-  }, [subId, relay, groupId, createSubscription, removeSubscription]);
+
+    createSubscription({ filters, relayUrls, onEvent });
+  }, [subId, relay, groupId, createSubscription]);
 
   const isLoading = useMemo(() => (!events || events.length == 0) && !eose, [events, eose]);
 

--- a/src/nip29/queries/use-group-thread-comments/index.ts
+++ b/src/nip29/queries/use-group-thread-comments/index.ts
@@ -7,18 +7,6 @@ import { Nip29GroupThreadComment } from '../../types';
 
 const addGroupThreadComment = useNip29Store.getState().addGroupThreadComment;
 
-const onEvent = (subId: string | undefined, groupId: string | undefined, event: NDKEvent) => {
-  const threadComment: Nip29GroupThreadComment = {
-    id: event.id,
-    pubkey: event.pubkey,
-    content: event.content,
-    timestamp: event.created_at || 0,
-    rootId: event.getMatchingTags('E')?.[0]?.[1] || '',
-  };
-
-  addGroupThreadComment(subId, groupId, threadComment);
-};
-
 export const useGroupThreadComments = (
   relay: string | undefined,
   groupId: string | undefined,
@@ -47,8 +35,7 @@ export const useGroupThreadComments = (
     subId && groupId ? state.groups[subId]?.[groupId]?.threadComments : undefined
   );
 
-  const { events, hasMore, isLoading, createSubscription, loadMore, removeSubscription } =
-    useSubscription(subId);
+  const { events, hasMore, isLoading, createSubscription, loadMore } = useSubscription(subId);
 
   useEffect(() => {
     if (!relay || !groupId || !subId) return;
@@ -64,12 +51,22 @@ export const useGroupThreadComments = (
     if (filter?.since) f.since = filter.since;
     if (filter?.until) f.until = filter.until;
 
-    const sub = createSubscription([f], {}, [relay]);
-    sub?.on('event', (event) => onEvent(subId, groupId, event));
+    const filters = [f];
+    const relayUrls = [relay];
 
-    return () => {
-      removeSubscription();
+    const onEvent = (event: NDKEvent) => {
+      const threadComment: Nip29GroupThreadComment = {
+        id: event.id,
+        pubkey: event.pubkey,
+        content: event.content,
+        timestamp: event.created_at || 0,
+        rootId: event.getMatchingTags('E')?.[0]?.[1] || '',
+      };
+
+      addGroupThreadComment(subId, groupId, threadComment);
     };
+
+    createSubscription({ filters, relayUrls, onEvent });
   }, [
     subId,
     relay,
@@ -83,7 +80,6 @@ export const useGroupThreadComments = (
     filter?.since,
     filter?.until,
     createSubscription,
-    removeSubscription,
   ]);
 
   return {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -81,14 +81,15 @@ export const useStore = create<State & Actions>()(
       },
 
       // subscription actions
-      createSubscription: (
+      createSubscription: ({
         subId,
         filters,
         opts,
         relayUrls,
+        onEvent,
         autoStart,
-        replaceOlderReplaceableEvents
-      ) => {
+        replaceOlderReplaceableEvents,
+      }) => {
         if (!subId) return null;
 
         const sub = get().subscriptions[subId];
@@ -116,6 +117,7 @@ export const useStore = create<State & Actions>()(
 
         subscription.on('event', (event) => {
           get().addEvent(subId, event, replaceOlderReplaceableEvents);
+          onEvent?.(event);
         });
         subscription.on('eose', () => {
           get().setEose(subId, true);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -21,14 +21,17 @@ export type Subscriptions = Record<
   }
 >;
 
-export type CreateSubscription = (
-  subId: string,
-  filters: NDKFilter[],
-  opts?: NDKSubscriptionOptions,
-  relayUrls?: string[],
-  autoStart?: boolean,
-  replaceOlderReplaceableEvents?: boolean
-) => NDKSubscription | null;
+export type CreateSubscriptionParams = {
+  subId: string;
+  filters: NDKFilter[];
+  opts?: NDKSubscriptionOptions;
+  relayUrls?: string[];
+  autoStart?: boolean;
+  onEvent?: (event: NDKEvent) => void;
+  replaceOlderReplaceableEvents?: boolean;
+};
+
+export type CreateSubscription = (params: CreateSubscriptionParams) => NDKSubscription | null;
 
 export type RemoveSubscription = (subId: string | undefined) => void;
 


### PR DESCRIPTION
This pull request focuses on improving the subscription handling in the `nostr-hooks` library by removing the `removeSubscription` method and simplifying the subscription management logic. Additionally, it updates the version in the `package.json` file.

### Subscription Handling Improvements:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L86-R94): Removed the `removeSubscription` method and its related cleanup code from the `useSubscription` hook examples. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L86-R94) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L292-R296)
* [`src/hooks/use-subscription/index.ts`](diffhunk://#diff-8dd52b5804e5541f18f6fed8fbaabaedaa759d3b511189d695944e01572f178aL1-R3): Updated the `createSubscription` method to use a new parameter type and added a cleanup callback for the subscription. [[1]](diffhunk://#diff-8dd52b5804e5541f18f6fed8fbaabaedaa759d3b511189d695944e01572f178aL1-R3) [[2]](diffhunk://#diff-8dd52b5804e5541f18f6fed8fbaabaedaa759d3b511189d695944e01572f178aL26-R27) [[3]](diffhunk://#diff-8dd52b5804e5541f18f6fed8fbaabaedaa759d3b511189d695944e01572f178aR49-R54)

### Group Metadata and Events:

* [`src/nip29/queries/use-all-groups-metadata-records/index.ts`](diffhunk://#diff-e3088605e045661b9d365d5357352f07415cac0e38bd80ab009bd19fca5b20afL10-L32): Simplified the subscription creation and event handling for group metadata records. [[1]](diffhunk://#diff-e3088605e045661b9d365d5357352f07415cac0e38bd80ab009bd19fca5b20afL10-L32) [[2]](diffhunk://#diff-e3088605e045661b9d365d5357352f07415cac0e38bd80ab009bd19fca5b20afL52-R59)
* [`src/nip29/queries/use-group-admins/index.ts`](diffhunk://#diff-40e84e2ab938ad22aaf2f08aea8c2c17f6a15545663eb3d86e59f064ab7d90fbL10-R37): Simplified the subscription creation and event handling for group admins.
* [`src/nip29/queries/use-group-chats/index.ts`](diffhunk://#diff-211d1252151c4332f87cd46709847a6948819a7a80e27847ab1e8f8e15e089c7L10-L21): Simplified the subscription creation and event handling for group chats. [[1]](diffhunk://#diff-211d1252151c4332f87cd46709847a6948819a7a80e27847ab1e8f8e15e089c7L10-L21) [[2]](diffhunk://#diff-211d1252151c4332f87cd46709847a6948819a7a80e27847ab1e8f8e15e089c7L50-R38) [[3]](diffhunk://#diff-211d1252151c4332f87cd46709847a6948819a7a80e27847ab1e8f8e15e089c7L67-R69) [[4]](diffhunk://#diff-211d1252151c4332f87cd46709847a6948819a7a80e27847ab1e8f8e15e089c7L86)
* [`src/nip29/queries/use-group-join-requests/index.ts`](diffhunk://#diff-310b5669cca0f3984d32387dafa49bd8d2687d21bde76e79d144336cb0503482L10-L21): Simplified the subscription creation and event handling for group join requests. [[1]](diffhunk://#diff-310b5669cca0f3984d32387dafa49bd8d2687d21bde76e79d144336cb0503482L10-L21) [[2]](diffhunk://#diff-310b5669cca0f3984d32387dafa49bd8d2687d21bde76e79d144336cb0503482L46-R34) [[3]](diffhunk://#diff-310b5669cca0f3984d32387dafa49bd8d2687d21bde76e79d144336cb0503482L61-R63) [[4]](diffhunk://#diff-310b5669cca0f3984d32387dafa49bd8d2687d21bde76e79d144336cb0503482L78)
* [`src/nip29/queries/use-group-leave-requests/index.ts`](diffhunk://#diff-730ac857d99dc5d6e915d01b0b62fca61881fda7cbd98c0e8b748a59c388116aL10-L20): Simplified the subscription creation and event handling for group leave requests. [[1]](diffhunk://#diff-730ac857d99dc5d6e915d01b0b62fca61881fda7cbd98c0e8b748a59c388116aL10-L20) [[2]](diffhunk://#diff-730ac857d99dc5d6e915d01b0b62fca61881fda7cbd98c0e8b748a59c388116aL45-R34) [[3]](diffhunk://#diff-730ac857d99dc5d6e915d01b0b62fca61881fda7cbd98c0e8b748a59c388116aL60-R62) [[4]](diffhunk://#diff-730ac857d99dc5d6e915d01b0b62fca61881fda7cbd98c0e8b748a59c388116aL77)
* [`src/nip29/queries/use-group-members/index.ts`](diffhunk://#diff-6b0d8a5dbe2d9e7078805d8ded18fb7ad649f379661223e95a5c89635621b644L10-R35): Simplified the subscription creation and event handling for group members.

### Version Update:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version from `4.1.9` to `4.2.0`.