### PR TITLE
V4.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nostr-hooks",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "description": "React hooks for developing Nostr clients",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/src/hooks/use-subscription/index.ts
+++ b/src/hooks/use-subscription/index.ts
@@ -1,7 +1,7 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo } from 'react';
 
-import { CreateSubscriptionParams } from 'src/types';
 import { useStore } from '../../store';
+import { CreateSubscriptionParams } from '../../types';
 import { useNdk } from '../use-ndk';
 
 /**
@@ -46,7 +46,7 @@ export const useSubscription = (subId: string | undefined) => {
     [subscription?.events, subscription?.eose]
   );
 
-  useCallback(() => {
+  useEffect(() => {
     return () => {
       removeSubscription();
     };


### PR DESCRIPTION
This pull request includes several changes to the `nostr-hooks` package, focusing on updating dependencies and improving the `use-subscription` hook. The most important changes include updating the package version, adding a new import to the `use-subscription` hook, and replacing the `useCallback` hook with `useEffect` to fix cleanup handling.

### Package updates:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from `4.2.1` to `4.2.2`.

### Hook improvements:
* [`src/hooks/use-subscription/index.ts`](diffhunk://#diff-8dd52b5804e5541f18f6fed8fbaabaedaa759d3b511189d695944e01572f178aL1-R4): Added `useEffect` import and moved `CreateSubscriptionParams` import to align with other imports.
* [`src/hooks/use-subscription/index.ts`](diffhunk://#diff-8dd52b5804e5541f18f6fed8fbaabaedaa759d3b511189d695944e01572f178aL49-R49): Replaced `useCallback` with `useEffect` for the cleanup function to ensure proper subscription removal.