### PR TITLE
Fix hasMore in useSubscription hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Nostr-Hooks
 
+## 4.2.8
+
+Fixed `hasMore` issue in `useSubscription` hook when there are less events than the limit.
+
 ## 4.2.5
 
 Added more hooks, including:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nostr-hooks",
-  "version": "4.2.7",
+  "version": "4.2.8",
   "description": "React hooks for developing Nostr clients",
   "main": "dist/index.js",
   "module": "dist/index.js",


### PR DESCRIPTION
This pull request includes several changes to fix the `hasMore` issue in the `useSubscription` hook and update the package version. The most important changes are listed below:

### Bug Fixes:
* Fixed the `hasMore` issue in the `useSubscription` hook by updating the logic to correctly determine if there are more events than the limit. (`src/store/index.ts`) [[1]](diffhunk://#diff-6617a8982092b70693d565d280deb361a2c860ca52f2a1d23f537ce5d276023bL122-R124) [[2]](diffhunk://#diff-6617a8982092b70693d565d280deb361a2c860ca52f2a1d23f537ce5d276023bL230-R238)

### Documentation and Versioning:
* Updated the `CHANGELOG.md` file to include the fix for the `hasMore` issue in version 4.2.8. (`CHANGELOG.md`)
* Updated the package version to 4.2.8 in `package.json`. (`package.json`)