### PR TITLE
Fix hasMore logic to include edge case

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nostr-hooks",
-  "version": "4.2.8",
+  "version": "4.2.9",
   "description": "React hooks for developing Nostr clients",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -121,7 +121,7 @@ export const useStore = create<State & Actions>()(
 
           const events = get().subscriptions[subId || 'na']?.events || ([] as NDKEvent[]);
 
-          get().setHasMore(subId, events.length > filters.reduce((a, b) => a + (b.limit || 0), 0));
+          get().setHasMore(subId, events.length >= filters.reduce((a, b) => a + (b.limit || 0), 1));
         });
 
         set(
@@ -233,9 +233,9 @@ export const useStore = create<State & Actions>()(
           const events = get().subscriptions[subId || 'na']?.events || ([] as NDKEvent[]);
 
           const _lim =
-            limit || sub.subscription.filters.reduce((a, b) => a + (b.limit || 0), 0) || 50;
+            limit || sub.subscription.filters.reduce((a, b) => a + (b.limit || 0), 1) || 50;
 
-          get().setHasMore(subId, events.length > _lim);
+          get().setHasMore(subId, events.length >= _lim);
         });
       },
 


### PR DESCRIPTION
This pull request includes several changes to the `nostr-hooks` package, primarily focusing on version updates and adjustments to the event filtering logic in the store.

### Version Update:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the package version from `4.2.8` to `4.2.9`.

### Event Filtering Logic Adjustments:
* [`src/store/index.ts`](diffhunk://#diff-6617a8982092b70693d565d280deb361a2c860ca52f2a1d23f537ce5d276023bL124-R124): Modified the condition in the `setHasMore` method to use `>=` instead of `>`, ensuring that the event length comparison is inclusive.
* [`src/store/index.ts`](diffhunk://#diff-6617a8982092b70693d565d280deb361a2c860ca52f2a1d23f537ce5d276023bL236-R238): Adjusted the default accumulator value in the `reduce` function for filter limits from `0` to `1`, ensuring that the comparison accounts for at least one event.